### PR TITLE
Add for osSensor package capture inside VPC.

### DIFF
--- a/templates/darktrace-vsensor-workload.template.yaml
+++ b/templates/darktrace-vsensor-workload.template.yaml
@@ -533,9 +533,6 @@ Resources:
                   if [ "$exitcode" -gt 0 ]; then
                       echo "Failed to successfully configure vSensor, more details in /var/log/user-data.log"
                       aws autoscaling complete-lifecycle-action --lifecycle-action-result ABANDON --instance-id $INSTANCE_ID --lifecycle-hook-name "${lifecycleHookName}" --auto-scaling-group-name "${autoScalingGroupName}"  --region ${AWS::Region} 
-                  else
-                      echo "Successful configuration of vSensor."
-                      aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id $INSTANCE_ID --lifecycle-hook-name "${lifecycleHookName}" --auto-scaling-group-name "${autoScalingGroupName}"  --region ${AWS::Region}
                   fi
                   exit "$exitcode"
               }
@@ -717,6 +714,9 @@ Resources:
               echo "Cloudwatch configuration complete."
               service confconsole restart || true # To update AWS screenshot with current config.
               touch /etc/darktrace/.userdata-confconsole-restart
+              echo "Successful configuration of vSensor. Telling AWS vSensor is ready for ASG, without waiting for upgrades."
+              aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id $INSTANCE_ID --lifecycle-hook-name "${lifecycleHookName}" --auto-scaling-group-name "${autoScalingGroupName}"  --region ${AWS::Region}
+              touch /etc/darktrace/.userdata-sent-success
               repo-control.sh -nevua ${VsensorUpdatekey} || true
               touch /etc/darktrace/.userdata-completed
               echo "Update configuration checks complete"
@@ -761,7 +761,7 @@ Resources:
           - ShortID: !GetAtt ShortIDRand.IDString
       AutoScalingGroupName: !Ref ASG
       DefaultResult: ABANDON
-      HeartbeatTimeout: 3600
+      HeartbeatTimeout: 300
       LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
 
   vSensorLogGroup:

--- a/templates/darktrace-vsensor-workload.template.yaml
+++ b/templates/darktrace-vsensor-workload.template.yaml
@@ -852,6 +852,23 @@ Resources:
       TargetType: 'instance'
       VpcId: !Ref DeploymentVPC
 
+  TargetGroupTCP80:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties: 
+      Name:
+        !Sub
+          - "${ShortID}-vSensor-ASG-TCP80"
+          - ShortID: !GetAtt ShortIDRand.IDString
+      HealthCheckEnabled: true
+      HealthCheckIntervalSeconds: 30
+      HealthCheckPath: /
+      HealthCheckPort: '80'
+      HealthCheckProtocol: HTTP
+      Port: 80
+      Protocol: 'TCP'
+      TargetType: 'instance'
+      VpcId: !Ref DeploymentVPC
+
   ASG:
     DependsOn: PCAPCleanupBucketOnDelete # Such that on deletion, the ASG is removed before emptying S3.
     Type: 'AWS::AutoScaling::AutoScalingGroup'
@@ -865,6 +882,7 @@ Resources:
       TargetGroupARNs: 
         - !Ref TargetGroupUDP4789
         - !Ref TargetGroupTCP443
+        - !Ref TargetGroupTCP80
       LaunchTemplate:
         Version: !GetAtt 
           - LaunchTemplate
@@ -1104,6 +1122,16 @@ Resources:
          TargetGroupArn: !Ref TargetGroupTCP443
       LoadBalancerArn: !Ref LoadBalancer
       Port: 443
+      Protocol: 'TCP'
+
+  LoadBalancerListenerTCP80:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties: 
+      DefaultActions: 
+       - Type: "forward"
+         TargetGroupArn: !Ref TargetGroupTCP80
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
       Protocol: 'TCP'
 
 


### PR DESCRIPTION
*Issue #, if available:*
 N/A

*Description of changes:*
- Adds port 80 to traffic mirroring load balancer in order to support osSensor in the VPC.
- Also improves scaling speed by finishing system updates after successfull configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
