### PR TITLE
Add bastion toggle, logging / cleanup improvements and disk encryption

### DIFF
--- a/templates/darktrace-vsensor-ami.template.yaml
+++ b/templates/darktrace-vsensor-ami.template.yaml
@@ -28,6 +28,8 @@ Metadata:
         default: Update Key
       LogGroupName:
         default: CloudWatch Log Group
+      LogGroupRetention:
+        default: Log Group Retention Period
       KeyPairName:
         default: EC2 Key-pair Name
       VPCSubnetId:
@@ -48,6 +50,28 @@ Parameters:
     Type: String
     Description: The CloudWatch log group that the AMI creation process should log to.
     Default: Darktrace-vSensor-Quickstart
+  LogGroupRetention:
+    Type: Number
+    AllowedValues:
+      - 1
+      - 3
+      - 5
+      - 7
+      - 14
+      - 30
+      - 60
+      - 90
+      - 120
+      - 150
+      - 180
+      - 365
+      - 400
+      - 545
+      - 731
+      - 1827
+      - 3653
+    Description: Number of days to retain Cloudwatch logs.
+    Default: 30
   KeyPairName:
     Type: 'AWS::EC2::KeyPair::KeyName'
     Description: Which EC2 Key-pair should be used to connect to the vSensor?
@@ -272,6 +296,12 @@ Resources:
       KeyName: !Ref KeyPairName
       IamInstanceProfile: !Ref AMIInstanceProfile
       InstanceType: "t3.medium"
+      BlockDeviceMappings:
+        - DeviceName: "/dev/sda1"
+          Ebs:
+            VolumeSize: 20
+            Encrypted: true
+            DeleteOnTermination: true
       Tags:
         - Key: Name
           Value: !Ref TargetAmiSSMName
@@ -359,6 +389,7 @@ Resources:
                   - 'wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb || exit 1'
                   - 'sudo dpkg -i -E ./amazon-cloudwatch-agent.deb || exit 1'
                   - 'systemctl enable amazon-cloudwatch-agent || exit 1'
+                  - 'systemctl disable unattended-upgrades || exit 1' # Disable unattended upgrades so it doesn't interfere on boot. Re-enabled in userdata script.
                   - 'sleep 20' # Sleep just to make sure the machine is settled before letting SSM shut it down for snapshotting.
                   # If any steps fails signals CFN of Failure
               CloudWatchOutputConfig:
@@ -451,22 +482,6 @@ Resources:
           Action:
           - sts:AssumeRole
       Policies:
-        -
-          PolicyName: allowLambdaLogging
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              -
-                Effect: "Allow"
-                Action:
-                  - 'logs:CreateLogStream'
-                  - 'logs:GetLogEvents'
-                  - 'logs:PutLogEvents'
-                  - 'logs:DescribeLogGroups'
-                  - 'logs:DescribeLogStreams'
-                  - 'logs:PutRetentionPolicy'
-                  - 'logs:CreateLogGroup'
-                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
         - PolicyName: AMICleanupLambdaPolicy
           PolicyDocument:
             Version: '2012-10-17'
@@ -476,16 +491,11 @@ Resources:
                 - ec2:DeregisterImage
               Resource:
                 - !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}::image/*'
-        - PolicyName: SSMAccess
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: 'Allow'
-                Action:
-                  - 'ssm:GetParameter'
-                Resource:
-                  - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
-
+            - Effect: Allow
+              Action:
+                - ec2:DescribeImages
+              Resource:
+                - '*'
   CleanupAMIOnDeleteLambda:
     DependsOn: BuildEC2Instance
     Type: "AWS::Lambda::Function"
@@ -498,48 +508,53 @@ Resources:
           import json
           import boto3
           import urllib3
-          def deregister_ami(region, parameter_name):
+          def deregister_ami(region, image_name):
               """
               Empties and deletes the AMI
               :param AMI_name:
               :return:
               """
               ec2_client = boto3.client('ec2', region_name=region)
-              ssm_client = boto3.client('ssm')
 
               ami_id = None
 
               # Work out which AMI we're deleting.
-              try:
-                response = ssm_client.get_parameter(
-                    Name=parameter_name,
-                )
-                print(response)
-                ami_id = response["Parameter"]["Value"]
-                print("Found AMI ID to delete: {} ".format(ami_id))
+              response = ec2_client.describe_images(
+                  Filters=[
+                      {
+                          'Name': 'name',
+                          'Values': [
+                              image_name,
+                          ]
+                      },
+                  ]
+              )
+              if len(response["Images"]) != 1:
+                raise Exception("Couldn't find single image in: {}".format(str(images)))
 
+              ami_id = response["Images"][0]["ImageId"]
+              print("Found AMI ID to delete: {} ".format(ami_id))
+
+              # Now deregister the AMI.
+              try:
+                response = ec2_client.deregister_image(
+                    ImageId=ami_id
+                )
               except Exception:
-                print("Parameter {} does not exist".format(parameter_name))
+                print("Failed to deregister AMI ID: {}".format(ami_id))
                 return
 
-              if ami_id:
-                # Now deregister the AMI.
-                try:
-                  response = ec2_client.deregister_image(
-                      ImageId=ami_id
-                  )
-                except Exception:
-                  print("Failed to deregister AMI ID: {}".format(ami_id))
-                  return
-
-                print ("Successfully deleted AMI: {}".format(ami_id))
+              print ("Successfully deleted AMI: {}".format(ami_id))
 
           def lambda_handler(event, context):
               try:
                   region = event['ResourceProperties']['Region']
-                  parameter_name = event['ResourceProperties']['SSMParameterName']
+                  parameter_name = event['ResourceProperties']['ImageName']
+                  # Only deregister if we are deleting the custom resource (Cloudformation is deleting)
                   if event['RequestType'] == 'Delete':
                       deregister_ami(region, parameter_name)
+                  else:
+                      print("Skipping deregistering AMI, stack is not deleting.")
 
                   sendResponseCfn(event, context, "SUCCESS")
               except Exception as e:
@@ -579,11 +594,35 @@ Resources:
       Runtime: python3.8
       Timeout: 60
 
+  CleanupAMIOnDeleteLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${CleanupAMIOnDeleteLambda}"
+      RetentionInDays: !Ref LogGroupRetention
+      
+  CleanupAMIOnDeleteLogPermissions:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+        - !Ref CleanupAMIOnDeleteLambdaRole
+      PolicyName: !Sub "${ShortID}-vSensor-AMI-Cleanup-LambdaLogGroup"
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - logs:CreateLogStream
+          - logs:PutLogEvents
+          Resource:
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${CleanupAMIOnDeleteLambda}"
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${CleanupAMIOnDeleteLambda}:*"
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${CleanupAMIOnDeleteLambda}:*:*"
+
   CleanupAMIOnDelete:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken: !GetAtt CleanupAMIOnDeleteLambda.Arn
       Region: !Sub "${AWS::Region}"
-      SSMParameterName: !Sub
+      ImageName: !Sub
         - "${ShortID}-vSensor-AMI"
         - ShortID: !Ref ShortID

--- a/templates/darktrace-vsensor-main.template.yaml
+++ b/templates/darktrace-vsensor-main.template.yaml
@@ -21,6 +21,7 @@ Metadata:
     - Label:
         default: Bastion configuration
       Parameters:
+        - BastionEnable
         - BastionInstanceType
         - BastionKeyPairName
         - BastionAMIOS
@@ -79,6 +80,8 @@ Metadata:
 
       # Bastion Config
 
+      BastionEnable:
+        default: Deploy with Bastion host?
       BastionInstanceType:
         default: Bastion host instance type
       BastionKeyPairName:
@@ -233,6 +236,13 @@ Parameters:
   
   # Bastion Config
 
+  BastionEnable:
+    Default: 'Yes'
+    Description: Use the AWS Quickstart Bastion template to deploy a public Bastion host to access your vSensor deployment. If 'No' is selected, configure your ssh access manually after deployment.
+    Type: String
+    AllowedValues:
+      - 'Yes'
+      - 'No'
   BastionInstanceType:
     # Limit to Nitro instances, compatible with Traffic Mirroring.
     AllowedValues:
@@ -354,6 +364,9 @@ Conditions:
   UsingDefaultBucket: !Equals
     - !Ref QSS3BucketName
     - "aws-quickstart"
+  CreateBastion: !Equals 
+    - !Ref BastionEnable
+    - "Yes"
 
 Resources:
 
@@ -373,23 +386,6 @@ Resources:
             - lambda.amazonaws.com
           Action:
           - sts:AssumeRole
-      Policies:
-        -
-          PolicyName: allowLambdaLogging
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              -
-                Effect: "Allow"
-                Action:
-                  - 'logs:CreateLogStream'
-                  - 'logs:GetLogEvents'
-                  - 'logs:PutLogEvents'
-                  - 'logs:DescribeLogGroups'
-                  - 'logs:DescribeLogStreams'
-                  - 'logs:PutRetentionPolicy'
-                  - 'logs:CreateLogGroup'
-                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
 
   RandomStringLambdaFunction:
     Type: AWS::Lambda::Function
@@ -424,8 +420,33 @@ Resources:
         MemorySize: 128
         Timeout: 20
 
+  RandomStringLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${RandomStringLambdaFunction}"
+      RetentionInDays: !Ref VSensorLogGroupRetention
+      
+  RandomStringLambdaLogPermissions:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+        - !Ref LambdaExecutionRole
+      PolicyName: !Sub "${RandomStringLambdaFunction}-LogGroup"
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - logs:CreateLogStream
+          - logs:PutLogEvents
+          Resource:
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${RandomStringLambdaFunction}"
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${RandomStringLambdaFunction}:*"
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${RandomStringLambdaFunction}:*:*"
+
   ShortIDRand:
     Type: AWS::CloudFormation::CustomResource
+    DependsOn: RandomStringLambdaLogPermissions
     Properties:
       Length: 12
       ShortID: !Ref ShortID
@@ -472,6 +493,7 @@ Resources:
   BastionStack:
 
     Type: AWS::CloudFormation::Stack
+    Condition: CreateBastion
     DeletionPolicy: Delete
     Properties:
       TemplateURL:
@@ -486,11 +508,15 @@ Resources:
               - !Ref "AWS::Region"
               - !Ref "QSS3BucketRegion"
       Parameters:
-        BastionHostName: !Sub 'DT-vSensorBastion-${AWS::StackName}'
+        BastionHostName:
+          !Sub
+            - "${ShortID}-vSensor-Bastion"
+            - ShortID: !GetAtt ShortIDRand.IDString
         BastionAMIOS:
           Ref: BastionAMIOS
         BastionInstanceType:
           Ref: BastionInstanceType
+        EnableTCPForwarding: true
         KeyPairName:
           Ref: BastionKeyPairName
         PublicSubnet1ID:
@@ -550,12 +576,14 @@ Resources:
             - VPCStack
             - Outputs.VPCID
         InstanceType: !Ref VSensorInstanceType
+        # If customer uses bastion, allow bastion NSG access to vSensors.
         InstanceSecurityGroups:
-          !Join
-            - ","
-            - - Fn::GetAtt:
-                - BastionStack
-                - Outputs.BastionSecurityGroupID
+          Fn::If:
+            - CreateBastion
+            - Fn::GetAtt:
+              - BastionStack
+              - Outputs.BastionSecurityGroupID
+            - ""
         LifecycleS3BucketDays: !Ref VSensorLifecycleS3BucketDays
         DesiredCapacityASG: !Ref VSensorDesiredCapacityASG
         MinSizeASG: !Ref VSensorMinSizeASG

--- a/templates/darktrace-vsensor-main.template.yaml
+++ b/templates/darktrace-vsensor-main.template.yaml
@@ -415,7 +415,7 @@ Resources:
               response.send(event, context, response.SUCCESS, responseData);
             };
         Handler: index.handler
-        Runtime: nodejs12.x
+        Runtime: nodejs16.x
         Role: !GetAtt LambdaExecutionRole.Arn
         MemorySize: 128
         Timeout: 20

--- a/templates/darktrace-vsensor-workload.template.yaml
+++ b/templates/darktrace-vsensor-workload.template.yaml
@@ -325,7 +325,7 @@ Resources:
               response.send(event, context, response.SUCCESS, responseData);
             };
         Handler: index.handler
-        Runtime: nodejs12.x
+        Runtime: nodejs16.x
         Role: !GetAtt LambdaExecutionRole.Arn
         MemorySize: 128
         Timeout: 20

--- a/templates/darktrace-vsensor-workload.template.yaml
+++ b/templates/darktrace-vsensor-workload.template.yaml
@@ -137,8 +137,8 @@ Parameters:
     Type: 'AWS::EC2::KeyPair::KeyName'
     Description: EC2 key pair to use to connect to vSensor.
   InstanceSecurityGroups:
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
-    Description: Darktrace vSensor security group IDs. A basic vSensor connectivity Security Group (port 80, 443, 4789 for the VPC) will be added by this cloudformation.
+    Type: 'CommaDelimitedList'
+    Description: Darktrace vSensor security group IDs. A basic vSensor connectivity Security Group (port 80, 443, 4789 for the VPC) will be additionally added by this cloudformation.
   VsensorUpdatekey:
     AllowedPattern: ^[a-zA-Z0-9%\.]+:[a-zA-Z0-9]+$
     Type: String
@@ -271,9 +271,12 @@ Parameters:
     Type: String
 
 Conditions:
-  UsingDefaultBucket: !Equals 
+  UsingDefaultBucket: !Equals
     - !Ref QSS3BucketName
-    -  "aws-quickstart"
+    - "aws-quickstart"
+  NotUsingExtraInstanceSecurityGroups: !Equals
+    - !Join [",", !Ref "InstanceSecurityGroups"]
+    - ""
     
 Resources:
 
@@ -293,23 +296,6 @@ Resources:
             - lambda.amazonaws.com
           Action:
           - sts:AssumeRole
-      Policies:
-        -
-          PolicyName: allowLambdaLogging
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              -
-                Effect: "Allow"
-                Action:
-                  - 'logs:CreateLogStream'
-                  - 'logs:GetLogEvents'
-                  - 'logs:PutLogEvents'
-                  - 'logs:DescribeLogGroups'
-                  - 'logs:DescribeLogStreams'
-                  - 'logs:PutRetentionPolicy'
-                  - 'logs:CreateLogGroup'
-                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
 
   RandomStringLambdaFunction:
     Type: AWS::Lambda::Function
@@ -344,8 +330,33 @@ Resources:
         MemorySize: 128
         Timeout: 20
 
+  RandomStringLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${RandomStringLambdaFunction}"
+      RetentionInDays: !Ref LogGroupRetention
+      
+  RandomStringLambdaLogPermissions:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+        - !Ref LambdaExecutionRole
+      PolicyName: !Sub "${RandomStringLambdaFunction}-LogGroup"
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - logs:CreateLogStream
+          - logs:PutLogEvents
+          Resource:
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${RandomStringLambdaFunction}"
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${RandomStringLambdaFunction}:*"
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${RandomStringLambdaFunction}:*:*"
+
   ShortIDRand:
     Type: AWS::CloudFormation::CustomResource
+    DependsOn: RandomStringLambdaLogPermissions
     Properties:
       Length: 12
       ShortID: !Ref ShortID 
@@ -387,6 +398,7 @@ Resources:
           !Sub
             - "${ShortID}-vSensor-Logs"
             - ShortID: !GetAtt ShortIDRand.IDString
+        LogGroupRetention: !Ref LogGroupRetention
         KeyPairName: !Ref KeyPairName
         VPCSubnetId:
           !Select
@@ -426,96 +438,17 @@ Resources:
           ToPort: 4789
           CidrIp: !Ref VpcCIDRBlock
 
-  ScaleDownAlarmMEM:
-    Type: AWS::CloudWatch::Alarm
-    Properties: 
-      AlarmActions:
-        - !Ref ScaleDownPolicy
-      AlarmDescription: Alarm to decide when vSensor should scale down
-      AlarmName:
-        !Sub
-          - "${ShortID}-vSensorScalingDownMEM"
-          - ShortID: !GetAtt ShortIDRand.IDString
-      ComparisonOperator: LessThanOrEqualToThreshold
-      EvaluationPeriods: 5
-      MetricName: "mem_used_percent"
-      Statistic: Average
-      Namespace: vSensorMetrics
-      Dimensions:
-      - Name: AutoScalingGroupName
-        Value: !Ref ASG
-      Period: 60
-      Threshold: 25
-
-  ScaleUpAlarmCPU:
-    Type: AWS::CloudWatch::Alarm
-    Properties: 
-      AlarmActions:
-        - !Ref ScaleUpPolicy
-      AlarmDescription: Alarm to decide when vSensor should scale up
-      AlarmName:
-        !Sub
-          - "${ShortID}-vSensorScalingUpCPU"
-          - ShortID: !GetAtt ShortIDRand.IDString
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 5
-      MetricName: "cpu_usage_active"
-      Statistic: Average
-      Namespace: vSensorMetrics
-      Dimensions:
-      - Name: AutoScalingGroupName
-        Value: !Ref ASG
-      Period: 60
-      Threshold: 75
-
-  ScaleUpAlarmMEM:
-    Type: AWS::CloudWatch::Alarm
-    Properties: 
-      AlarmActions:
-        - !Ref ScaleUpPolicy
-      AlarmDescription: Alarm to decide when vSensor should scale up
-      AlarmName:
-        !Sub
-          - "${ShortID}-vSensorScalingUpMEM"
-          - ShortID: !GetAtt ShortIDRand.IDString
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 5
-      MetricName: "mem_used_percent"
-      Statistic: Average
-      Namespace: vSensorMetrics
-      Dimensions:
-      - Name: AutoScalingGroupName
-        Value: !Ref ASG
-      Period: 60
-      Threshold: 75
-
-  ScaleDownPolicy:
+  ScalingPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties: 
-      AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: !Ref ASG
-      MetricAggregationType: Average
-      PolicyType: StepScaling
-      StepAdjustments: 
-        - MetricIntervalUpperBound: -15
-          ScalingAdjustment: -2
-        - MetricIntervalLowerBound: -15
-          MetricIntervalUpperBound: 0
-          ScalingAdjustment: -1
+      EstimatedInstanceWarmup: 600
+      PolicyType: TargetTrackingScaling
+      TargetTrackingConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ASGAverageCPUUtilization
+        TargetValue: 75
 
-  ScaleUpPolicy:
-    Type: AWS::AutoScaling::ScalingPolicy
-    Properties: 
-      AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref ASG
-      MetricAggregationType: Average
-      PolicyType: StepScaling
-      StepAdjustments: 
-        - MetricIntervalLowerBound: 0
-          MetricIntervalUpperBound: 15
-          ScalingAdjustment: 1
-        - MetricIntervalLowerBound: 15
-          ScalingAdjustment: 2
 
   LaunchTemplate:
     Type: 'AWS::EC2::LaunchTemplate'
@@ -534,6 +467,7 @@ Resources:
                       echo "Failed to successfully configure vSensor, more details in /var/log/user-data.log"
                       aws autoscaling complete-lifecycle-action --lifecycle-action-result ABANDON --instance-id $INSTANCE_ID --lifecycle-hook-name "${lifecycleHookName}" --auto-scaling-group-name "${autoScalingGroupName}"  --region ${AWS::Region} 
                   fi
+                  systemctl enable unattended-upgrades
                   exit "$exitcode"
               }
 
@@ -542,33 +476,13 @@ Resources:
 
               trap "exittrap" EXIT
 
-              # See https://youtu.be/unMiTRw8JVE for an example on how to review this console output.
+              # See https://youtu.be/unMiTRw8JVE for an example on how to review this console output if Cloudwatch logging fails.
               echo "Starting userdata"
 
               echo "Getting instance ID and attempt to disable source-dest checking metadata."
               INSTANCE_ID=$(ec2metadata --instance-id)
               aws ec2 modify-instance-attribute --no-source-dest-check --instance-id $INSTANCE_ID --region ${AWS::Region} || echo "Failed to set source-dest. Continuing anyway." # Not serious if this doesn't succeed.
 
-              echo "Running firstboot scripts"
-              /usr/lib/inithooks/firstboot.d/15random-uuid
-              /usr/lib/inithooks/firstboot.d/15regen-sslkeys
-              touch /etc/darktrace/.userdata-firstboot-complete
-
-              echo "Setting configuration"
-              #set updatekey, upgrade and enable daily updates
-              set_updatekey.sh ${VsensorUpdatekey}
-              sudo sed -i --follow-symlinks "/\[[Ss]erver\]/a EphemeralProbe=true" /etc/sabreserver/local_lite.cfg # Configure vSensor for use in ASG.
-              sudo sed -i --follow-symlinks "/\[[Ss]erver\]/a osSensorProvideRoute=true" /etc/sabreserver/local_lite.cfg #set_pushtoken will restart sabre-server-lite
-              set_pushtoken.sh ${AppliancePushtoken} ${ApplianceHostname}:${AppliancePort}
-              sleep 5
-              if [ -n "${osSensorHMAC}" ]; then
-                set_ossensor_hmac.sh ${osSensorHMAC}
-                sleep 5
-              fi
-              set_pcap_s3_bucket.sh ${PCAPS}
-              sleep 5
-              touch /etc/darktrace/.userdata-config-complete
-              echo "Completed vSensor configuration"
               cat >CW_AGENT.conf <<'EOF'
               {
                 "agent": {
@@ -623,6 +537,11 @@ Resources:
                           "file_path": "/var/log/nginx/access.log",
                           "log_group_name": "${vSensorLogGroup}",
                           "log_stream_name": "{instance_id}"
+                        },
+                        {
+                          "file_path": "/var/log/user-data.log",
+                          "log_group_name": "${vSensorLogGroup}",
+                          "log_stream_name": "{instance_id}-userdata"
                         }
                       ]
                     }
@@ -712,14 +631,34 @@ Resources:
               sudo systemctl start amazon-cloudwatch-agent
               touch /etc/darktrace/.userdata-cw-complete
               echo "Cloudwatch configuration complete."
+
+              echo "Running firstboot scripts"
+              /usr/lib/inithooks/firstboot.d/15random-uuid
+              /usr/lib/inithooks/firstboot.d/15regen-sslkeys
+              touch /etc/darktrace/.userdata-firstboot-complete
+
+              echo "Setting configuration"
+              sudo sed -i --follow-symlinks "/\[[Ss]erver\]/a EphemeralProbe=true" /etc/sabreserver/local_lite.cfg # Configure vSensor for use in ASG.
+              sudo sed -i --follow-symlinks "/\[[Ss]erver\]/a osSensorProvideRoute=true" /etc/sabreserver/local_lite.cfg #set_pushtoken will restart sabre-server-lite
+              set_pushtoken.sh ${AppliancePushtoken} ${ApplianceHostname}:${AppliancePort}
+              sleep 5
+              if [ -n "${osSensorHMAC}" ]; then
+                set_ossensor_hmac.sh ${osSensorHMAC}
+                sleep 5
+              fi
+              set_pcap_s3_bucket.sh ${PCAPS}
+              sleep 5
+              touch /etc/darktrace/.userdata-config-complete
+              echo "Completed vSensor configuration"
               service confconsole restart || true # To update AWS screenshot with current config.
+              #set updatekey, upgrade and enable daily updates
+              set_updatekey.sh ${VsensorUpdatekey}
               touch /etc/darktrace/.userdata-confconsole-restart
               echo "Successful configuration of vSensor. Telling AWS vSensor is ready for ASG, without waiting for upgrades."
               aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id $INSTANCE_ID --lifecycle-hook-name "${lifecycleHookName}" --auto-scaling-group-name "${autoScalingGroupName}"  --region ${AWS::Region}
               touch /etc/darktrace/.userdata-sent-success
-              repo-control.sh -nevua ${VsensorUpdatekey} || true
+              apt-get update && /usr/sbin/cron-apt-dist-upgrade.sh || true
               touch /etc/darktrace/.userdata-completed
-              echo "Update configuration checks complete"
               echo "Userdata script complete."
             - autoScalingGroupName: !Sub
                 - "${ShortID}-vSensor-ASG"
@@ -733,11 +672,17 @@ Resources:
           - DeviceName: "/dev/sda1"
             Ebs:
               VolumeSize: 20
-        SecurityGroupIds: !Split
-            - ","
-            - !Sub 
-              - "${customerSecurityGroups},${SecurityGroupvSensor}"
-              - customerSecurityGroups: !Join [",", !Ref "InstanceSecurityGroups"]
+              Encrypted: true
+              DeleteOnTermination: true
+        SecurityGroupIds:
+          Fn::If:
+              - NotUsingExtraInstanceSecurityGroups
+              - - !Sub "${SecurityGroupvSensor}"
+              - !Split
+                - ","
+                - !Sub 
+                  - "${SecurityGroupvSensor},${customerSecurityGroups}"
+                  - customerSecurityGroups: !Join [",", !Ref "InstanceSecurityGroups"]
         IamInstanceProfile:
           Arn: !GetAtt vSensorIamInstanceProfile.Arn
         ImageId: !GetAtt vSensorAmiName.Value
@@ -746,23 +691,12 @@ Resources:
             Tags:
               - Key: 'vSensorProbe'
                 Value: 'YES'
+        Monitoring:
+          Enabled: true
       LaunchTemplateName:
         !Sub
           - "${ShortID}-vSensor-Launch-Template"
           - ShortID: !GetAtt ShortIDRand.IDString
-
-  # Used in UserData for ASG vSensors to wait for configuration completion / failure before adding to Load Balancer.
-  LifecycleStartHook:
-    Type: AWS::AutoScaling::LifecycleHook
-    Properties:
-      LifecycleHookName:
-        !Sub
-          - "${ShortID}-vSensor-LifecycleHook"
-          - ShortID: !GetAtt ShortIDRand.IDString
-      AutoScalingGroupName: !Ref ASG
-      DefaultResult: ABANDON
-      HeartbeatTimeout: 300
-      LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
 
   vSensorLogGroup:
     Type: 'AWS::Logs::LogGroup'
@@ -873,6 +807,9 @@ Resources:
     DependsOn: PCAPCleanupBucketOnDelete # Such that on deletion, the ASG is removed before emptying S3.
     Type: 'AWS::AutoScaling::AutoScalingGroup'
     Properties:
+      AutoScalingGroupName: !Sub
+        - "${ShortID}-vSensor-ASG"
+        - ShortID: !GetAtt ShortIDRand.IDString
       MinSize: !Ref MinSizeASG
       MaxSize: !Ref MaxSizeASG
       MetricsCollection: 
@@ -890,13 +827,13 @@ Resources:
         LaunchTemplateId: !Ref LaunchTemplate
       HealthCheckType: "ELB"
       HealthCheckGracePeriod: 60
-      Tags:
-        - Key: Name
-          PropagateAtLaunch: True
-          Value:
-            !Sub
-              - "${ShortID}-vSensor-ASG"
-              - ShortID: !GetAtt ShortIDRand.IDString
+      LifecycleHookSpecificationList:
+        - LifecycleHookName: !Sub
+            - "${ShortID}-vSensor-LifecycleHook"
+            - ShortID: !GetAtt ShortIDRand.IDString
+          DefaultResult: ABANDON
+          HeartbeatTimeout: 300
+          LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
 
 # PCAPS S3 Bucket
 
@@ -938,21 +875,6 @@ Resources:
           - sts:AssumeRole
       Path: "/"
       Policies:
-        - PolicyName: allowLambdaLogging
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              -
-                Effect: "Allow"
-                Action:
-                  - 'logs:CreateLogStream'
-                  - 'logs:GetLogEvents'
-                  - 'logs:PutLogEvents'
-                  - 'logs:DescribeLogGroups'
-                  - 'logs:DescribeLogStreams'
-                  - 'logs:PutRetentionPolicy'
-                  - 'logs:CreateLogGroup'
-                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
         - PolicyName: !Sub
             - "${ShortID}-vSensor-S3CleanupLambdaPolicy"
             - ShortID: !GetAtt ShortIDRand.IDString
@@ -1041,6 +963,8 @@ Resources:
                   bucket = event['ResourceProperties']['BucketName']
                   if event['RequestType'] == 'Delete':
                       empty_delete_buckets(bucket)
+                  else:
+                      print("Skipping PCAP bucket deletion, cloudformation stack is not deleting.")
 
                   sendResponseCfn(event, context, "SUCCESS")
               except Exception as e:
@@ -1077,9 +1001,33 @@ Resources:
         - "${ShortID}-vSensor-PCAPS-Cleanup"
         - ShortID: !GetAtt ShortIDRand.IDString
       Handler: index.lambda_handler
-      Role : !GetAtt CleanupBucketOnDeleteLambdaRole.Arn
+      Role: !GetAtt CleanupBucketOnDeleteLambdaRole.Arn
       Runtime: python3.8
       Timeout: 60
+
+  CleanupBucketOnDeleteLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${CleanupBucketOnDeleteLambda}"
+      RetentionInDays: !Ref LogGroupRetention
+      
+  CleanupBucketOnDeleteLambdaLogPermissions:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+        - !Ref CleanupBucketOnDeleteLambdaRole
+      PolicyName: !Sub "${ShortID}-vSensor-PCAPS-Cleanup-LambdaLogGroup"
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - logs:CreateLogStream
+          - logs:PutLogEvents
+          Resource:
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${CleanupBucketOnDeleteLambda}"
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${CleanupBucketOnDeleteLambda}:*"
+          - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${CleanupBucketOnDeleteLambda}:*:*"
 
   PCAPCleanupBucketOnDelete:
     Type: AWS::CloudFormation::CustomResource
@@ -1207,9 +1155,7 @@ Resources:
             Statement:
             - Effect: "Allow"
               Action: "ec2:ModifyInstanceAttribute"
-              Resource: !Sub
-                - "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
-                - SecurityGroup: !GetAtt SecurityGroupvSensor.GroupId
+              Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
 
 Outputs:
   BucketName:


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

* Add toggle to allow customers to save expenses and complexity by disabling the Bastion template (by configuring access using existing setups after deployment).
* Enforces disk encryption on vSensor disks.
* Apply the log rotation parameter to more of the Cloudwatch logging generated by this template.
* Switch to target tracking scaling for improved scaling behaviour with customer supplied configuration.
* Change vSensor scale up update behaviour to improve CPU usage.
* Fixes AMI cleanup by using EC2 API rather than SSM Parameters to detect AMI to remove. SSM parameter was deleted before AMI cleanup could run.
* Moves lifecycle hook definition into ASG configuration to remove race condition causing initial vSensor instance to not have the lifecycle applied.
* Bump lambads using nodejs12 to nodejs16.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
